### PR TITLE
Fix 2 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ torchvision
 mmdet==2.26.0
 mmengine
 numpy==1.22.0
-protobuf==3.20.1
+protobuf == 4.21.6 
 timm
 scikit-image
 gradio


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Sat, 16 Dec 2023 11:32:31 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | requirements.txt | pillow | [CVE-2016-4009](https://nvd.nist.gov/vuln/detail/CVE-2016-4009) | 9.8 | fixed in 3.3.1, 3.1.1 | Integer overflow in the ImagingResampleHorizontal function in libImaging/Resample.c in Pillow before 3.1.1 allows remote attackers to have unspecified impact via negative values of the new size, which triggers a heap-based buffer overflow.
critical | requirements.txt | pillow | [CVE-2020-5311](https://nvd.nist.gov/vuln/detail/CVE-2020-5311) | 9.8 | fixed in 6.2.2 | libImaging/SgiRleDecode.c in Pillow before 6.2.2 has an SGI buffer overflow.
critical | requirements.txt | pillow | [CVE-2020-5312](https://nvd.nist.gov/vuln/detail/CVE-2020-5312) | 9.8 | fixed in 6.2.2 | libImaging/PcxDecode.c in Pillow before 6.2.2 has a PCX P mode buffer overflow.
critical | requirements.txt | pillow | [CVE-2021-25287](https://nvd.nist.gov/vuln/detail/CVE-2021-25287) | 9.1 | fixed in 8.2.0 | An issue was discovered in Pillow before 8.2.0. There is an out-of-bounds read in J2kDecode, in j2ku_graya_la.
critical | requirements.txt | pillow | [CVE-2021-25288](https://nvd.nist.gov/vuln/detail/CVE-2021-25288) | 9.1 | fixed in 8.2.0 | An issue was discovered in Pillow before 8.2.0. There is an out-of-bounds read in J2kDecode, in j2ku_gray_i.
critical | requirements.txt | pillow | [CVE-2021-25289](https://nvd.nist.gov/vuln/detail/CVE-2021-25289) | 9.8 | fixed in 8.1.1 | An issue was discovered in Pillow before 8.1.1. TiffDecode has a heap-based buffer overflow when decoding crafted YCbCr files because of certain interpretation conflicts with LibTIFF in RGBA mode. NOTE: this issue exists because of an incomplete fix for CVE-2020-35654.
critical | requirements.txt | pillow | [CVE-2022-22817](https://nvd.nist.gov/vuln/detail/CVE-2022-22817) | 9.8 | fixed in 9.0.0 | PIL.ImageMath.eval in Pillow before 9.0.0 allows evaluation of arbitrary expressions, such as ones that use the Python exec method. A lambda expression could also be used.
critical | requirements.txt | pillow | [CVE-2022-24303](https://nvd.nist.gov/vuln/detail/CVE-2022-24303) | 9.1 | fixed in 9.0.1 | Pillow before 9.0.1 allows attackers to delete files because spaces in temporary pathnames are mishandled.
high | requirements.txt | pillow | [PRISMA-2021-0015](https://github.com/python-pillow/Pillow/pull/5148) | 0.0 | fixed in 8.1.0 | In Pillow versions prior to 8.1.0, OOB Read occurs when saving TIFFs with custom metadata through LibTIFF.
high | requirements.txt | pillow | [PRISMA-2021-0010](https://github.com/python-pillow/Pillow/pull/5149) | 0.0 | fixed in 8.1.0 | In Pillow versions prior 8.1.0, OOB Read occurs when saving GIF of xsize=1.
high | requirements.txt | pillow | [CVE-2016-9190](https://nvd.nist.gov/vuln/detail/CVE-2016-9190) | 7.8 | fixed in 3.3.2 | Pillow before 3.3.2 allows context-dependent attackers to execute arbitrary code by using the \"crafted image file\" approach, related to an \"Insecure Sign Extension\" issue affecting the ImagingNew in Storage.c component.
high | requirements.txt | pillow | [CVE-2019-16865](https://nvd.nist.gov/vuln/detail/CVE-2019-16865) | 7.5 | fixed in 6.2.0 | An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image.
high | requirements.txt | pillow | [CVE-2019-19911](https://nvd.nist.gov/vuln/detail/CVE-2019-19911) | 7.5 | fixed in 6.2.2 | There is a DoS vulnerability in Pillow before 6.2.2 caused by FpxImagePlugin.py calling the range function on an unvalidated 32-bit integer if the number of bands is large. On Windows running 32-bit Python, this results in an OverflowError or MemoryError due to the 2 GB limit. However, on Linux running 64-bit Python this results in the process being terminated by the OOM killer.
high | requirements.txt | pillow | [CVE-2022-45199](https://nvd.nist.gov/vuln/detail/CVE-2022-45199) | 7.5 | fixed in 9.3.0 | Pillow before 9.3.0 allows denial of service via SAMPLESPERPIXEL.
high | requirements.txt | pillow | [CVE-2022-45198](https://nvd.nist.gov/vuln/detail/CVE-2022-45198) | 7.5 | fixed in 9.2.0 | Pillow before 9.2.0 performs Improper Handling of Highly Compressed GIF Data (Data Amplification).
high | requirements.txt | pillow | [CVE-2020-10379](https://nvd.nist.gov/vuln/detail/CVE-2020-10379) | 7.8 | fixed in 7.1.0 | In Pillow before 7.1.0, there are two Buffer Overflows in libImaging/TiffDecode.c.
high | requirements.txt | pillow | [CVE-2020-11538](https://nvd.nist.gov/vuln/detail/CVE-2020-11538) | 8.1 | fixed in 7.1.0 | In libImaging/SgiRleDecode.c in Pillow through 7.0.0, a number of out-of-bounds reads exist in the parsing of SGI image files, a different issue than CVE-2020-5311.
high | requirements.txt | pillow | [CVE-2020-35653](https://nvd.nist.gov/vuln/detail/CVE-2020-35653) | 7.1 | fixed in 8.1.0 | In Pillow before 8.1.0, PcxDecode has a buffer over-read when decoding a crafted PCX file because the user-supplied stride value is trusted for buffer calculations.
high | requirements.txt | pillow | [CVE-2020-35654](https://nvd.nist.gov/vuln/detail/CVE-2020-35654) | 8.8 | fixed in 8.1.0 | In Pillow before 8.1.0, TiffDecode has a heap-based buffer overflow when decoding crafted YCbCr files because of certain interpretation conflicts with LibTIFF in RGBA mode.
high | requirements.txt | pillow | [CVE-2020-5310](https://nvd.nist.gov/vuln/detail/CVE-2020-5310) | 8.8 | fixed in 6.2.2 | libImaging/TiffDecode.c in Pillow before 6.2.2 has a TIFF decoding integer overflow, related to realloc.
high | requirements.txt | pillow | [CVE-2020-5313](https://nvd.nist.gov/vuln/detail/CVE-2020-5313) | 7.1 | fixed in 6.2.2 | libImaging/FliDecode.c in Pillow before 6.2.2 has an FLI buffer overflow.
high | requirements.txt | pillow | [CVE-2021-25290](https://nvd.nist.gov/vuln/detail/CVE-2021-25290) | 7.5 | fixed in 8.1.1 | An issue was discovered in Pillow before 8.1.1. In TiffDecode.c, there is a negative-offset memcpy with an invalid size.
high | requirements.txt | pillow | [CVE-2021-25291](https://nvd.nist.gov/vuln/detail/CVE-2021-25291) | 7.5 | fixed in 8.1.1 | An issue was discovered in Pillow before 8.1.1. In TiffDecode.c, there is an out-of-bounds read in TiffreadRGBATile via invalid tile boundaries.
high | requirements.txt | pillow | [CVE-2021-25293](https://nvd.nist.gov/vuln/detail/CVE-2021-25293) | 7.5 | fixed in 8.1.1 | An issue was discovered in Pillow before 8.1.1. There is an out-of-bounds read in SGIRleDecode.c.
high | requirements.txt | pillow | [CVE-2021-27921](https://nvd.nist.gov/vuln/detail/CVE-2021-27921) | 7.5 | fixed in 8.1.1 | Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for a BLP container, and thus an attempted memory allocation can be very large.
high | requirements.txt | pillow | [CVE-2021-27922](https://nvd.nist.gov/vuln/detail/CVE-2021-27922) | 7.5 | fixed in 8.1.1 | Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for an ICNS container, and thus an attempted memory allocation can be very large.
high | requirements.txt | pillow | [CVE-2021-27923](https://nvd.nist.gov/vuln/detail/CVE-2021-27923) | 7.5 | fixed in 8.1.1 | Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for an ICO container, and thus an attempted memory allocation can be very large.
high | requirements.txt | pillow | [CVE-2021-28676](https://nvd.nist.gov/vuln/detail/CVE-2021-28676) | 7.5 | fixed in 8.2.0 | An issue was discovered in Pillow before 8.2.0. For FLI data, FliDecode did not properly check that the block advance was non-zero, potentially leading to an infinite loop on load.
high | requirements.txt | pillow | [CVE-2021-28677](https://nvd.nist.gov/vuln/detail/CVE-2021-28677) | 7.5 | fixed in 8.2.0 | An issue was discovered in Pillow before 8.2.0. For EPS data, the readline implementation used in EPSImageFile has to deal with any combination of \r and \n as line endings. It used an accidentally quadratic method of accumulating lines while looking for a line ending. A malicious EPS file could use this to perform a DoS of Pillow in the open phase, before an image was accepted for opening.
high | requirements.txt | pillow | [CVE-2023-4863](https://nvd.nist.gov/vuln/detail/CVE-2023-4863) | 8.8 | fixed in 10.0.1 | Heap buffer overflow in libwebp in Google Chrome prior to 116.0.5845.187 and libwebp 1.3.2 allowed a remote attacker to perform an out of bounds memory write via a crafted HTML page. (Chromium security severity: Critical)
high | requirements.txt | pillow | [GHSA-56pw-mpj4-fxww](https://github.com/advisories/GHSA-56pw-mpj4-fxww) | 7.0 | fixed in 10.0.1 | Pillow versions before v10.0.1 bundled libwebp binaries in wheels that are vulnerable to CVE-2023-5129 (previously CVE-2023-4863). Pillow v10.0.1 upgrades the bundled libwebp binary to v1.3.2.
high | requirements.txt | pillow | [CVE-2023-44271](https://nvd.nist.gov/vuln/detail/CVE-2023-44271) | 7.5 | fixed in 10.0.0 | An issue was discovered in Pillow before 10.0.0. It is a Denial of Service that uncontrollably allocates memory to process a given task, potentially causing a service to crash by having it run out of memory. This occurs for truetype in ImageFont when textlength in an ImageDraw instance operates on a long text argument.
high | requirements.txt | protobuf | [CVE-2022-1941](https://nvd.nist.gov/vuln/detail/CVE-2022-1941) | 7.5 | fixed in 4.21.6, 3.20.2, 3.19.5, 3.18.3 | A parsing vulnerability for the MessageSet type in the ProtocolBuffers versions prior to and including 3.16.1, 3.17.3, 3.18.2, 3.19.4, 3.20.1 and 3.21.5 for protobuf-cpp, and versions prior to and including 3.16.1, 3.17.3, 3.18.2, 3.19.4, 3.20.1 and 4.21.5 for protobuf-python can lead to out of memory failures. A specially crafted message with multiple key-value per elements creates parsing issues, and can lead to a Denial of Service against services receiving unsanitized input. We recommend upgrading to versions 3.18.3, 3.19.5, 3.20.2, 3.21.6 for protobuf-cpp and 3.18.3, 3.19.5, 3.20.2, 4.21.6 for protobuf-python. Versions for 3.16 and 3.17 are no longer updated.
medium | requirements.txt | pillow | [CVE-2016-0740](https://nvd.nist.gov/vuln/detail/CVE-2016-0740) | 6.5 | fixed in 3.3.1, 3.1.1 | Buffer overflow in the ImagingLibTiffDecode function in libImaging/TiffDecode.c in Pillow before 3.1.1 allows remote attackers to overwrite memory via a crafted TIFF file.
medium | requirements.txt | pillow | [CVE-2016-0775](https://nvd.nist.gov/vuln/detail/CVE-2016-0775) | 6.5 | fixed in 3.3.1, 3.1.1 | Buffer overflow in the ImagingFliDecode function in libImaging/FliDecode.c in Pillow before 3.1.1 allows remote attackers to cause a denial of service (crash) via a crafted FLI file.
medium | requirements.txt | pillow | [CVE-2016-9189](https://nvd.nist.gov/vuln/detail/CVE-2016-9189) | 5.5 | fixed in 3.3.2 | Pillow before 3.3.2 allows context-dependent attackers to obtain sensitive information by using the \"crafted image file\" approach, related to an \"Integer Overflow\" issue affecting the Image.core.map_buffer in map.c component.
medium | requirements.txt | pillow | [CVE-2020-10177](https://nvd.nist.gov/vuln/detail/CVE-2020-10177) | 5.5 | fixed in 7.1.0 | Pillow before 7.1.0 has multiple out-of-bounds reads in libImaging/FliDecode.c.
medium | requirements.txt | pillow | [CVE-2020-10378](https://nvd.nist.gov/vuln/detail/CVE-2020-10378) | 5.5 | fixed in 7.1.0 | In libImaging/PcxDecode.c in Pillow before 7.1.0, an out-of-bounds read can occur when reading PCX files where state->shuffle is instructed to read beyond state->buffer.
medium | requirements.txt | pillow | [CVE-2020-10994](https://nvd.nist.gov/vuln/detail/CVE-2020-10994) | 5.5 | fixed in 7.1.0 | In libImaging/Jpeg2KDecode.c in Pillow before 7.1.0, there are multiple out-of-bounds reads via a crafted JP2 file.
medium | requirements.txt | pillow | [CVE-2021-25292](https://nvd.nist.gov/vuln/detail/CVE-2021-25292) | 6.5 | fixed in 8.1.1 | An issue was discovered in Pillow before 8.1.1. The PDF parser allows a regular expression DoS (ReDoS) attack via a crafted PDF file because of a catastrophic backtracking regex.
medium | requirements.txt | pillow | [CVE-2021-28675](https://nvd.nist.gov/vuln/detail/CVE-2021-28675) | 5.5 | fixed in 8.2.0 | An issue was discovered in Pillow before 8.2.0. PSDImagePlugin.PsdImageFile lacked a sanity check on the number of input layers relative to the size of the data block. This could lead to a DoS on Image.open prior to Image.load.
medium | requirements.txt | pillow | [CVE-2021-28678](https://nvd.nist.gov/vuln/detail/CVE-2021-28678) | 5.5 | fixed in 8.2.0 | An issue was discovered in Pillow before 8.2.0. For BLP data, BlpImagePlugin did not properly check that reads (after jumping to file offsets) returned data. This could lead to a DoS where the decoder could be run a large number of times on empty data.
medium | requirements.txt | pillow | [CVE-2022-22815](https://nvd.nist.gov/vuln/detail/CVE-2022-22815) | 6.5 | fixed in 9.0.0 | path_getbbox in path.c in Pillow before 9.0.0 improperly initializes ImagePath.Path.
medium | requirements.txt | pillow | [CVE-2022-22816](https://nvd.nist.gov/vuln/detail/CVE-2022-22816) | 6.5 | fixed in 9.0.0 | path_getbbox in path.c in Pillow before 9.0.0 has a buffer over-read during initialization of ImagePath.Path.
medium | requirements.txt | pillow | [CVE-2016-2533](https://nvd.nist.gov/vuln/detail/CVE-2016-2533) | 6.5 | fixed in 3.3.1, 3.1.1 | Buffer overflow in the ImagingPcdDecode function in PcdDecode.c in Pillow before 3.1.1 and Python Imaging Library (PIL) 1.1.7 and earlier allows remote attackers to cause a denial of service (crash) via a crafted PhotoCD file.
moderate | requirements.txt | pillow | [GHSA-jgpv-4h4c-xhw3](https://github.com/advisories/GHSA-jgpv-4h4c-xhw3) | 7.5 | fixed in 8.1.2 | ### Impact _Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for a BLP container, and thus an attempted memory allocation can be very large._  ### Patches _An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image._  ### Workarounds _An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image._  ### References https://nvd.nist.gov/vuln/detail/CVE-2021-27921  ### For more information If you have any questions or comments about this advisory: * Open an issue in [example link to repo](http://example.com) * Email us at [example email address](mailto:example@example.com)
low | requirements.txt | pillow | [GHSA-4fx9-vc88-q2xc](https://github.com/advisories/GHSA-4fx9-vc88-q2xc) | 1.0 | fixed in 9.0.0 | JpegImagePlugin may append an EOF marker to the end of a truncated file, so that the last segment of the data will still be processed by the decoder.  If the EOF marker is not detected as such however, this could lead to an infinite loop where JpegImagePlugin keeps trying to end the file.
